### PR TITLE
Refactor tooling TODOs

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "devDependencies": {
     "@dotenvx/dotenvx": "^1.44.1",
-    "oxc-transform": "^0.129.0",
     "oxfmt": "^0.48.0",
     "oxlint": "^1.63.0",
     "typescript": "^5.7.2"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint:fix": "yarn lint:ox:fix",
     "lint:ox": "yarn oxlint .",
     "lint:ox:fix": "yarn oxlint . --fix",
-    "nn-cli": "node packages/nn-cli/bin/dev.js",
+    "nn-cli": "node packages/nn-cli/bin/run.js",
     "publish": "yarn workspaces foreach -Apit --no-private npm publish --tolerate-republish",
     "bump:patch": "yarn workspaces foreach -Apit --no-private version patch"
   },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@dotenvx/dotenvx": "^1.44.1",
+    "oxc-transform": "^0.133.0",
     "oxfmt": "^0.48.0",
     "oxlint": "^1.63.0",
     "typescript": "^5.7.2"

--- a/packages/nn-analyzer/package.json
+++ b/packages/nn-analyzer/package.json
@@ -2,13 +2,12 @@
   "name": "@nn-lang/nn-analyzer",
   "version": "0.1.8",
   "scripts": {
-    "build": "node ../../scripts/oxc-build.cjs .",
+    "build": "node ../../scripts/ts-build.cjs .",
     "clean": "rm -rf ./out"
   },
   "dependencies": {
     "@nn-lang/nn-language": "workspace:^",
-    "@nn-lang/nn-type-checker": "workspace:^",
-    "@oxc-project/runtime": "^0.129.0"
+    "@nn-lang/nn-type-checker": "workspace:^"
   },
   "main": "out/src/index.js",
   "typings": "src/index.ts"

--- a/packages/nn-analyzer/package.json
+++ b/packages/nn-analyzer/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.8",
   "type": "module",
   "scripts": {
-    "build": "node ../../scripts/ts-build.cjs .",
+    "build": "node ../../scripts/oxc-build.cjs .",
     "clean": "rm -rf ./out"
   },
   "dependencies": {

--- a/packages/nn-analyzer/package.json
+++ b/packages/nn-analyzer/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@nn-lang/nn-analyzer",
   "version": "0.1.8",
+  "type": "module",
   "scripts": {
     "build": "node ../../scripts/ts-build.cjs .",
     "clean": "rm -rf ./out"

--- a/packages/nn-cli/bin/dev.js
+++ b/packages/nn-cli/bin/dev.js
@@ -1,6 +1,11 @@
-#!/usr/bin/env node_modules/.bin/ts-node
+#!/usr/bin/env node
+
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
 
 (async () => {
   const oclif = await import("@oclif/core");
-  await oclif.execute({ development: true, dir: __dirname });
+  await oclif.execute({ dir: currentDir });
 })();

--- a/packages/nn-cli/bin/run.js
+++ b/packages/nn-cli/bin/run.js
@@ -1,6 +1,11 @@
 #!/usr/bin/env node
 
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+
 (async () => {
   const oclif = await import("@oclif/core");
-  await oclif.execute({ dir: __dirname });
+  await oclif.execute({ dir: currentDir });
 })();

--- a/packages/nn-cli/package.json
+++ b/packages/nn-cli/package.json
@@ -2,6 +2,7 @@
   "name": "@nn-lang/nn-cli",
   "description": "A new CLI generated with oclif",
   "version": "0.1.10",
+  "type": "module",
   "author": "SieR-VR",
   "bin": "./bin/run.js",
   "bugs": "https://github.com/nn-lang/nn/issues",

--- a/packages/nn-cli/package.json
+++ b/packages/nn-cli/package.json
@@ -52,12 +52,12 @@
   },
   "repository": "nn-lang/nn",
   "scripts": {
-    "build": "shx rm -rf out && tsc -b",
+    "build": "node ../../scripts/oxc-build.cjs .",
     "lint": "yarn -T oxlint .",
     "postpack": "shx rm -f oclif.manifest.json",
     "posttest": "yarn lint",
     "prepack": "oclif manifest && oclif readme",
     "version": "oclif readme && git add README.md"
   },
-  "types": "out/index.d.ts"
+  "types": "src/index.ts"
 }

--- a/packages/nn-cli/src/commands/check.ts
+++ b/packages/nn-cli/src/commands/check.ts
@@ -1,6 +1,6 @@
 import { Args, Command } from "@oclif/core";
 
-import { compilation, formatDiagnostic } from "../utils";
+import { compilation, formatDiagnostic } from "../utils.js";
 
 export default class Check extends Command {
   static args = {

--- a/packages/nn-cli/src/commands/onnx.ts
+++ b/packages/nn-cli/src/commands/onnx.ts
@@ -5,7 +5,7 @@ import { pathToFileURL } from "node:url";
 import Codegen from "@nn-lang/nn-codegen";
 import { Args, Command, Flags } from "@oclif/core";
 
-import { compilation, formatDiagnostic } from "../utils";
+import { compilation, formatDiagnostic } from "../utils.js";
 
 export default class Onnx extends Command {
   static args = {

--- a/packages/nn-cli/src/utils.ts
+++ b/packages/nn-cli/src/utils.ts
@@ -12,45 +12,19 @@ import { TypeChecker } from "@nn-lang/nn-type-checker";
 import Parser from "tree-sitter";
 import { Result, err, ok } from "ts-features";
 
-function isFileUri(value: string): boolean {
-  return value.startsWith("file://");
-}
-
-function toFilePath(uriOrPath: string): string {
-  return isFileUri(uriOrPath) ? url.fileURLToPath(uriOrPath) : uriOrPath;
-}
-
-function resolveDependencyPath(
-  fromUri: string,
-  reference: string,
-  cwd: string,
-): string {
-  if (isFileUri(fromUri)) {
-    return new url.URL(reference, fromUri).href;
-  }
-
-  const basePath = path.isAbsolute(fromUri)
-    ? fromUri
-    : path.resolve(cwd, fromUri);
-  const referencePath = isFileUri(reference)
-    ? url.fileURLToPath(reference)
-    : reference;
-
-  return path.resolve(path.dirname(basePath), referencePath);
-}
-
 export const CliFileSystem: CompilerFileSystem = {
-  dirname: (filePath) => path.normalize(path.dirname(filePath)),
-  resolve: (...paths) => path.normalize(path.join(...paths)),
+  dirname: CompilerFileSystem.dirname,
+  resolve: CompilerFileSystem.resolve,
 
   dependencyResolver: (fromUri, reference, options) =>
-    resolveDependencyPath(fromUri, reference, options.cwd),
+    CompilerFileSystem.resolveDependencyPath(fromUri, reference, options.cwd),
 
-  readFile: async (fileUri) => fs.readFile(toFilePath(fileUri), "utf-8"),
+  readFile: async (fileUri) =>
+    fs.readFile(CompilerFileSystem.toFilePath(fileUri), "utf-8"),
 
   writeFile: async (fileUri, content) => {
     try {
-      await fs.writeFile(toFilePath(fileUri), content);
+      await fs.writeFile(CompilerFileSystem.toFilePath(fileUri), content);
       return true;
     } catch {
       return false;
@@ -58,7 +32,10 @@ export const CliFileSystem: CompilerFileSystem = {
   },
   checkExists: async (fileUri) => {
     try {
-      await fs.access(toFilePath(fileUri), fs.constants.R_OK);
+      await fs.access(
+        CompilerFileSystem.toFilePath(fileUri),
+        fs.constants.R_OK,
+      );
       return true;
     } catch {
       return false;

--- a/packages/nn-cli/tsconfig.json
+++ b/packages/nn-cli/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "module": "commonjs",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
     "outDir": "out",
     "rootDir": "src",
     "strict": true,

--- a/packages/nn-codegen/package.json
+++ b/packages/nn-codegen/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@nn-lang/nn-codegen",
   "version": "0.1.8",
+  "type": "module",
   "scripts": {
     "build": "node ../../scripts/ts-build.cjs .",
     "clean": "rm -rf ./out"

--- a/packages/nn-codegen/package.json
+++ b/packages/nn-codegen/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.8",
   "type": "module",
   "scripts": {
-    "build": "node ../../scripts/ts-build.cjs .",
+    "build": "node ../../scripts/oxc-build.cjs .",
     "clean": "rm -rf ./out"
   },
   "dependencies": {

--- a/packages/nn-codegen/package.json
+++ b/packages/nn-codegen/package.json
@@ -2,13 +2,12 @@
   "name": "@nn-lang/nn-codegen",
   "version": "0.1.8",
   "scripts": {
-    "build": "node ../../scripts/oxc-build.cjs .",
+    "build": "node ../../scripts/ts-build.cjs .",
     "clean": "rm -rf ./out"
   },
   "dependencies": {
     "@nn-lang/nn-language": "workspace:^",
     "@nn-lang/nn-type-checker": "workspace:^",
-    "@oxc-project/runtime": "^0.129.0",
     "onnx-proto": "^8.0.1"
   },
   "main": "out/src/index.js",

--- a/packages/nn-codegen/src/onnx/attribute.ts
+++ b/packages/nn-codegen/src/onnx/attribute.ts
@@ -1,11 +1,14 @@
-import { onnx } from "onnx-proto";
+import onnxProto from "onnx-proto";
+import type { onnx as Onnx } from "onnx-proto";
+
+const { onnx } = onnxProto;
 
 const AttributeType = onnx.AttributeProto.AttributeType;
 
 export function flowAttribute(
   operator: string,
   sizes: Record<string, number>,
-): onnx.AttributeProto[] {
+): Onnx.AttributeProto[] {
   if (operator === "BatchNormalization") {
     return [
       makeAttr("epsilon", AttributeType.FLOAT, 1e-5),
@@ -61,7 +64,7 @@ export function flowAttribute(
   return [];
 }
 
-function makeAttr<T extends onnx.AttributeProto.AttributeType>(
+function makeAttr<T extends Onnx.AttributeProto.AttributeType>(
   name: string,
   type: T,
   value: MakeAttrValueType<T>,
@@ -73,9 +76,9 @@ function makeAttr<T extends onnx.AttributeProto.AttributeType>(
   });
 }
 
-type MakeAttrValueType<T extends onnx.AttributeProto.AttributeType> =
-  (typeof Helper)[T] extends keyof onnx.AttributeProto
-    ? onnx.AttributeProto[(typeof Helper)[T]]
+type MakeAttrValueType<T extends Onnx.AttributeProto.AttributeType> =
+  (typeof Helper)[T] extends keyof Onnx.AttributeProto
+    ? Onnx.AttributeProto[(typeof Helper)[T]]
     : never;
 
 const Helper = {
@@ -95,6 +98,6 @@ const Helper = {
   [onnx.AttributeProto.AttributeType.SPARSE_TENSORS]: "sparseTensors",
   [onnx.AttributeProto.AttributeType.TYPE_PROTOS]: "typeProtos",
 } satisfies Record<
-  onnx.AttributeProto.AttributeType,
-  keyof onnx.AttributeProto | undefined
+  Onnx.AttributeProto.AttributeType,
+  keyof Onnx.AttributeProto | undefined
 >;

--- a/packages/nn-codegen/src/onnx/flow.ts
+++ b/packages/nn-codegen/src/onnx/flow.ts
@@ -12,20 +12,23 @@ import {
   SizeType,
   TypeChecker,
 } from "@nn-lang/nn-type-checker";
-import { onnx } from "onnx-proto";
+import onnxProto from "onnx-proto";
+import type { onnx as Onnx } from "onnx-proto";
 
 import { flowAttribute } from "./attribute";
 import { TensorShape, TensorSizes } from "./tensor-shape";
 
+const { onnx } = onnxProto;
+
 export namespace OnnxNode {
-  const _nodeMap = new Map<string, onnx.NodeProto>();
+  const _nodeMap = new Map<string, Onnx.NodeProto>();
 
   function makeNode(
     flow: Flow,
     parent: string,
     inputs: string[],
     sizes: Map<Size, Polynomial>,
-  ): onnx.NodeProto {
+  ): Onnx.NodeProto {
     if (_nodeMap.has(parent)) return _nodeMap.get(parent)!;
 
     const record = [...sizes.entries()].reduce(
@@ -57,12 +60,12 @@ export namespace OnnxNode {
     sizes: Map<Size, Polynomial>,
     checker: TypeChecker,
   ): {
-    initializers: onnx.TensorProto[];
-    nodes: onnx.NodeProto[];
-    outputs: onnx.ValueInfoProto[];
+    initializers: Onnx.TensorProto[];
+    nodes: Onnx.NodeProto[];
+    outputs: Onnx.ValueInfoProto[];
   } {
-    const initializers: onnx.TensorProto[] = [];
-    const nodes: onnx.NodeProto[] = [];
+    const initializers: Onnx.TensorProto[] = [];
+    const nodes: Onnx.NodeProto[] = [];
     const edgeInputs: string[] = [];
 
     edge.args.forEach((arg) => {
@@ -151,9 +154,9 @@ export namespace OnnxNode {
     checker: TypeChecker,
     outerSizes?: Map<Size, Polynomial>,
   ): {
-    outputs: onnx.ValueInfoProto[];
-    initializers: onnx.TensorProto[];
-    nodes: onnx.NodeProto[];
+    outputs: Onnx.ValueInfoProto[];
+    initializers: Onnx.TensorProto[];
+    nodes: Onnx.NodeProto[];
   } {
     const flow = edge.callee.flow;
 

--- a/packages/nn-codegen/src/onnx/index.ts
+++ b/packages/nn-codegen/src/onnx/index.ts
@@ -1,10 +1,13 @@
 import { Workspace } from "@nn-lang/nn-language";
 import { TypeChecker } from "@nn-lang/nn-type-checker";
-import { onnx } from "onnx-proto";
+import onnxProto from "onnx-proto";
+import type { onnx as OnnxProtoTypes } from "onnx-proto";
 import { Result, err, ok } from "ts-features";
 
 import { OnnxNode } from "./flow";
 import { DEFAULT_OPSET_IMPORTS, ONNX_NN_DOMAIN } from "./node";
+
+const { onnx } = onnxProto;
 
 export namespace Onnx {
   export interface OnnxSettings {
@@ -44,12 +47,12 @@ export namespace Onnx {
     const initializerMap = initializers.reduce((map, initializer) => {
       map.set(initializer.name, initializer);
       return map;
-    }, new Map<string, onnx.ValueInfoProto>());
+    }, new Map<string, OnnxProtoTypes.ValueInfoProto>());
 
     const nodeMap = nodes.reduce((map, node) => {
       map.set(node.name, node);
       return map;
-    }, new Map<string, onnx.NodeProto>());
+    }, new Map<string, OnnxProtoTypes.NodeProto>());
 
     const modelProto = new onnx.ModelProto({
       irVersion: onnx.Version.IR_VERSION,

--- a/packages/nn-codegen/src/onnx/node.ts
+++ b/packages/nn-codegen/src/onnx/node.ts
@@ -11,7 +11,10 @@ import {
   isTupleExpression,
 } from "@nn-lang/nn-language";
 import { Flow, Polynomial, Size, TypeChecker } from "@nn-lang/nn-type-checker";
-import { onnx } from "onnx-proto";
+import onnxProto from "onnx-proto";
+import type { onnx as Onnx } from "onnx-proto";
+
+const { onnx } = onnxProto;
 
 export const DEFAULT_OPSET_IMPORTS = [
   new onnx.OperatorSetIdProto({
@@ -41,7 +44,7 @@ interface OnnxContext {
 export function declaration(
   decl: Declaration,
   context: OnnxContext,
-): onnx.FunctionProto {
+): Onnx.FunctionProto {
   const [input, output, nodes] = declarationNodes(decl, context);
 
   return new onnx.FunctionProto({
@@ -57,11 +60,11 @@ export function declaration(
 export function declarationNodes(
   decl: Declaration,
   context: OnnxContext,
-): [input: string[], output: string[], nodes: onnx.NodeProto[]] {
+): [input: string[], output: string[], nodes: Onnx.NodeProto[]] {
   const declArgs = decl.argumentList.args.map((arg) => arg.ident.value);
   let args = decl.firstPipe ? [...declArgs] : [];
 
-  const result: onnx.NodeProto[] = [];
+  const result: Onnx.NodeProto[] = [];
 
   for (const expr of decl.exprs) {
     if (isAssignmentExpression(expr)) {
@@ -149,7 +152,7 @@ export function assign(
   expr: AssignmentExpression,
   prevArgs: string[],
   context: OnnxContext,
-): [string[], onnx.NodeProto] {
+): [string[], Onnx.NodeProto] {
   if (!isCallExpression(expr.right)) {
     throw new Error("Unreachable");
   }
@@ -173,7 +176,7 @@ export function call(
   expr: CallExpression,
   prevArgs: string[],
   context: OnnxContext,
-): [string[], onnx.NodeProto] {
+): [string[], Onnx.NodeProto] {
   const result = new onnx.NodeProto({
     opType: expr.callee.value,
     domain: "nn",
@@ -187,7 +190,7 @@ export function call(
 export function tensorShape(
   flow: Flow,
   context: OnnxContext,
-): [onnx.TypeProto[], onnx.TypeProto] {
+): [Onnx.TypeProto[], Onnx.TypeProto] {
   const sizeMap = Object.entries(flow.declaration.sizes).reduce(
     (prev, [ident, size]) => {
       if (!context.sizeMap[ident]) {

--- a/packages/nn-codegen/src/onnx/tensor-shape.ts
+++ b/packages/nn-codegen/src/onnx/tensor-shape.ts
@@ -1,11 +1,14 @@
 import { Polynomial, Size, Type } from "@nn-lang/nn-type-checker";
-import { onnx } from "onnx-proto";
+import onnxProto from "onnx-proto";
+import type { onnx as Onnx } from "onnx-proto";
+
+const { onnx } = onnxProto;
 
 export namespace TensorShape {
   export function fromType(
     type: Type,
     sizes: Map<Size, Polynomial>,
-  ): onnx.TensorShapeProto {
+  ): Onnx.TensorShapeProto {
     return new onnx.TensorShapeProto({
       dim: type.shape
         .map(Polynomial.from)

--- a/packages/nn-language/package.json
+++ b/packages/nn-language/package.json
@@ -2,13 +2,12 @@
   "name": "@nn-lang/nn-language",
   "version": "0.1.15",
   "scripts": {
-    "build": "node ../../scripts/oxc-build.cjs .",
+    "build": "node ../../scripts/ts-build.cjs .",
     "clean": "rm -rf ./out"
   },
   "main": "out/src/index.js",
   "typings": "src/index.ts",
   "dependencies": {
-    "@oxc-project/runtime": "^0.129.0",
     "web-tree-sitter": "^0.25.3"
   }
 }

--- a/packages/nn-language/package.json
+++ b/packages/nn-language/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@nn-lang/nn-language",
   "version": "0.1.15",
+  "type": "module",
   "scripts": {
     "build": "node ../../scripts/ts-build.cjs .",
     "clean": "rm -rf ./out"

--- a/packages/nn-language/package.json
+++ b/packages/nn-language/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "scripts": {
-    "build": "node ../../scripts/ts-build.cjs .",
+    "build": "node ../../scripts/oxc-build.cjs .",
     "clean": "rm -rf ./out"
   },
   "main": "out/src/index.js",

--- a/packages/nn-language/src/utils.ts
+++ b/packages/nn-language/src/utils.ts
@@ -29,6 +29,38 @@ type BooleanCallback = (node: Node) => boolean;
 type TravelCallback<T> = T extends Node
   ? IsCallback<T>
   : (node: Node) => T | undefined;
+type TraversableRecord = Record<string, unknown>;
+
+function isTraversableRecord(value: unknown): value is TraversableRecord {
+  return typeof value === "object" && value !== null;
+}
+
+function isPositionRecord(value: TraversableRecord): boolean {
+  return typeof value["pos"] === "number" && typeof value["end"] === "number";
+}
+
+function isSourceFileRecord(value: TraversableRecord): boolean {
+  return (
+    typeof value["path"] === "string" &&
+    typeof value["content"] === "string" &&
+    Array.isArray(value["declarations"]) &&
+    Array.isArray(value["dependencies"]) &&
+    Array.isArray(value["diagnostics"])
+  );
+}
+
+function isNodeRecord(
+  value: TraversableRecord,
+): value is TraversableRecord & Node {
+  return (
+    typeof value["type"] === "string" &&
+    typeof value["id"] === "number" &&
+    isTraversableRecord(value["position"]) &&
+    isPositionRecord(value["position"]) &&
+    isTraversableRecord(value["source"]) &&
+    isSourceFileRecord(value["source"])
+  );
+}
 
 export function travel<T>(
   node: Node | Node[],
@@ -36,29 +68,30 @@ export function travel<T>(
 ): T[] {
   const result: T[] = [];
 
-  const _travel = (node: Node | Node[] | Node[keyof Node]) => {
-    if (
-      !node ||
-      typeof node === "string" ||
-      typeof node === "boolean" ||
-      typeof node === "number"
-    )
-      return;
-    if ("pos" in node || "path" in node) return;
-
-    if (Array.isArray(node)) {
-      node.forEach(_travel);
+  const _travel = (value: unknown) => {
+    if (!isTraversableRecord(value)) {
       return;
     }
 
-    const res = callback(node);
-    if (typeof res === "boolean") {
-      res && result.push(node as T);
-    } else if (res !== undefined) {
-      result.push(res);
+    if (Array.isArray(value)) {
+      value.forEach(_travel);
+      return;
     }
 
-    Object.values(node).forEach(_travel);
+    if (isPositionRecord(value) || isSourceFileRecord(value)) {
+      return;
+    }
+
+    if (isNodeRecord(value)) {
+      const res = callback(value);
+      if (typeof res === "boolean") {
+        res && result.push(value as T);
+      } else if (res !== undefined) {
+        result.push(res);
+      }
+    }
+
+    Object.values(value).forEach(_travel);
   };
 
   _travel(node);

--- a/packages/nn-language/src/workspace.ts
+++ b/packages/nn-language/src/workspace.ts
@@ -1,3 +1,6 @@
+import * as path from "node:path";
+import * as url from "node:url";
+
 import { CreateNodeState, Import, Parser, SourceFile } from ".";
 
 export interface CompilerOptions {
@@ -18,6 +21,43 @@ export interface CompilerFileSystem {
   readFile: (uri: string) => Promise<string>;
   writeFile: (uri: string, content: string) => Promise<boolean>;
   checkExists: (uri: string) => Promise<boolean>;
+}
+
+export namespace CompilerFileSystem {
+  export function isFileUri(value: string): boolean {
+    return value.startsWith("file://");
+  }
+
+  export function toFilePath(uriOrPath: string): string {
+    return isFileUri(uriOrPath) ? url.fileURLToPath(uriOrPath) : uriOrPath;
+  }
+
+  export function dirname(filePath: string): string {
+    return path.normalize(path.dirname(filePath));
+  }
+
+  export function resolve(...paths: string[]): string {
+    return path.normalize(path.join(...paths));
+  }
+
+  export function resolveDependencyPath(
+    fromUri: string,
+    reference: string,
+    cwd: string,
+  ): string {
+    if (isFileUri(fromUri)) {
+      return new url.URL(reference, fromUri).href;
+    }
+
+    const basePath = path.isAbsolute(fromUri)
+      ? fromUri
+      : path.resolve(cwd, fromUri);
+    const referencePath = isFileUri(reference)
+      ? url.fileURLToPath(reference)
+      : reference;
+
+    return path.resolve(path.dirname(basePath), referencePath);
+  }
 }
 
 export interface Dependency {

--- a/packages/nn-test/jest.config.ts
+++ b/packages/nn-test/jest.config.ts
@@ -2,8 +2,24 @@ import { JestConfigWithTsJest } from "ts-jest";
 
 const config: JestConfigWithTsJest = {
   roots: ["./tests"],
-  preset: "ts-jest",
+  extensionsToTreatAsEsm: [".ts"],
   maxWorkers: 1,
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
+  preset: "ts-jest/presets/default-esm",
+  transform: {
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      {
+        tsconfig: {
+          module: "ESNext",
+          moduleResolution: "Bundler",
+        },
+        useESM: true,
+      },
+    ],
+  },
 };
 
 export default config;

--- a/packages/nn-test/package.json
+++ b/packages/nn-test/package.json
@@ -2,8 +2,9 @@
   "name": "@nn-lang/nn-test",
   "version": "0.1.3",
   "private": true,
+  "type": "module",
   "scripts": {
-    "test": "jest"
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "dependencies": {
     "@nn-lang/nn-language": "workspace:^",

--- a/packages/nn-test/tests/checker.test.ts
+++ b/packages/nn-test/tests/checker.test.ts
@@ -2,14 +2,15 @@ import * as fs from "fs";
 import * as path from "path";
 import * as url from "url";
 
-import language = require("@nn-lang/nn-tree-sitter");
 import { Workspace } from "@nn-lang/nn-language";
+import language from "@nn-lang/nn-tree-sitter";
 import { TypeChecker } from "@nn-lang/nn-type-checker";
 import Parser from "tree-sitter";
 
-import { TestFileSystem } from "./utils";
+import { TestFileSystem } from "./utils.js";
 
-const file = fs.readdirSync(path.join(__dirname, "cases"));
+const currentDir = path.dirname(url.fileURLToPath(import.meta.url));
+const file = fs.readdirSync(path.join(currentDir, "cases"));
 const sources = file.filter((f) => f.endsWith(".nn"));
 
 describe("checker", () => {
@@ -18,7 +19,7 @@ describe("checker", () => {
       const parser = new Parser();
       parser.setLanguage(language as any);
       const options = {
-        cwd: path.join(__dirname, "cases"),
+        cwd: path.join(currentDir, "cases"),
         fileSystem: TestFileSystem,
       };
       const entryFileUri = url.pathToFileURL(path.join(options.cwd, file)).href;

--- a/packages/nn-test/tests/incremental.test.ts
+++ b/packages/nn-test/tests/incremental.test.ts
@@ -1,9 +1,14 @@
 import * as path from "path";
 import * as url from "url";
 
-import { Parser as NnParser, Workspace } from "@nn-lang/nn-language";
+import { Workspace } from "@nn-lang/nn-language";
+import type { Parser as NnParser } from "@nn-lang/nn-language";
+import language from "@nn-lang/nn-tree-sitter";
+import Parser from "tree-sitter";
 
-import { TestFileSystem } from "./utils";
+import { TestFileSystem } from "./utils.js";
+
+const currentDir = path.dirname(url.fileURLToPath(import.meta.url));
 
 function makeParserProxy(inner: NnParser): {
   proxy: NnParser;
@@ -22,14 +27,11 @@ function makeParserProxy(inner: NnParser): {
 
 describe("incremental parsing", () => {
   it("passes the previous tree to the parser on re-parse", async () => {
-    const Parser = require("tree-sitter");
-    const language = require("@nn-lang/nn-tree-sitter");
-
     const innerParser = new Parser();
-    innerParser.setLanguage(language);
+    innerParser.setLanguage(language as any);
 
     const options = {
-      cwd: path.join(__dirname, "cases"),
+      cwd: path.join(currentDir, "cases"),
       fileSystem: TestFileSystem,
     };
     const entryFileUri = url.pathToFileURL(

--- a/packages/nn-test/tests/parser.test.ts
+++ b/packages/nn-test/tests/parser.test.ts
@@ -2,13 +2,14 @@ import * as fs from "fs";
 import * as path from "path";
 import * as url from "url";
 
-import language = require("@nn-lang/nn-tree-sitter");
 import { Workspace } from "@nn-lang/nn-language";
+import language from "@nn-lang/nn-tree-sitter";
 import Parser from "tree-sitter";
 
-import { TestFileSystem, getErrorJson } from "./utils";
+import { TestFileSystem, getErrorJson } from "./utils.js";
 
-const file = fs.readdirSync(path.join(__dirname, "cases"));
+const currentDir = path.dirname(url.fileURLToPath(import.meta.url));
+const file = fs.readdirSync(path.join(currentDir, "cases"));
 
 const sources = file.filter((f) => f.endsWith(".nn"));
 const errors = file.filter((f) => f.endsWith(".error.json"));
@@ -26,7 +27,7 @@ describe("parser", () => {
       const parser = new Parser();
       parser.setLanguage(language as any);
       const options = {
-        cwd: path.join(__dirname, "cases"),
+        cwd: path.join(currentDir, "cases"),
         fileSystem: TestFileSystem,
       };
       const entryFileUri = url.pathToFileURL(path.join(options.cwd, file)).href;
@@ -51,11 +52,11 @@ describe("parser", () => {
       const parser = new Parser();
       parser.setLanguage(language as any);
       const options = {
-        cwd: path.join(__dirname, "cases"),
+        cwd: path.join(currentDir, "cases"),
         fileSystem: TestFileSystem,
       };
 
-      const errorJson = await getErrorJson(__dirname, file);
+      const errorJson = await getErrorJson(currentDir, file);
       const entryFileUri = url.pathToFileURL(path.join(options.cwd, file)).href;
       const workspace = await Workspace.create([entryFileUri], options, parser);
 

--- a/packages/nn-test/tests/utils.test.ts
+++ b/packages/nn-test/tests/utils.test.ts
@@ -1,4 +1,5 @@
-import { Node, SourceFile, travel } from "@nn-lang/nn-language";
+import { travel } from "@nn-lang/nn-language";
+import type { Node, SourceFile } from "@nn-lang/nn-language";
 
 const position = { pos: 0, end: 0 };
 

--- a/packages/nn-test/tests/utils.test.ts
+++ b/packages/nn-test/tests/utils.test.ts
@@ -1,0 +1,41 @@
+import { Node, SourceFile, travel } from "@nn-lang/nn-language";
+
+const position = { pos: 0, end: 0 };
+
+function createSource(): SourceFile {
+  return {
+    path: "file:///test.nn",
+    content: "",
+    declarations: [],
+    dependencies: [],
+    diagnostics: [],
+    _oldTree: null,
+  };
+}
+
+function createNode(source: SourceFile, id: number, type: string): Node {
+  return {
+    id,
+    type,
+    position,
+    source,
+  };
+}
+
+describe("utils", () => {
+  it("travels compiler nodes without visiting metadata records", () => {
+    const source = createSource();
+    const ident = createNode(source, 1, "Identifier");
+    const typeNode = createNode(source, 2, "TypeNode");
+    const argumentList = {
+      ...createNode(source, 3, "ArgumentList"),
+      args: [{ ident, valueType: typeNode }],
+    };
+
+    expect(travel(argumentList, (node) => node.type)).toStrictEqual([
+      "ArgumentList",
+      "Identifier",
+      "TypeNode",
+    ]);
+  });
+});

--- a/packages/nn-test/tests/utils.ts
+++ b/packages/nn-test/tests/utils.ts
@@ -1,6 +1,5 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import * as url from "node:url";
 
 import { CompilerFileSystem } from "@nn-lang/nn-language";
 
@@ -15,45 +14,19 @@ export async function getErrorJson(dirname: string, source: string) {
   return JSON.parse(await fs.readFile(filePath, "utf8"));
 }
 
-function isFileUri(value: string): boolean {
-  return value.startsWith("file://");
-}
-
-function toFilePath(uriOrPath: string): string {
-  return isFileUri(uriOrPath) ? url.fileURLToPath(uriOrPath) : uriOrPath;
-}
-
-function resolveDependencyPath(
-  fromUri: string,
-  reference: string,
-  cwd: string,
-): string {
-  if (isFileUri(fromUri)) {
-    return new url.URL(reference, fromUri).href;
-  }
-
-  const basePath = path.isAbsolute(fromUri)
-    ? fromUri
-    : path.resolve(cwd, fromUri);
-  const referencePath = isFileUri(reference)
-    ? url.fileURLToPath(reference)
-    : reference;
-
-  return path.resolve(path.dirname(basePath), referencePath);
-}
-
 export const TestFileSystem: CompilerFileSystem = {
-  dirname: (filePath) => path.normalize(path.dirname(filePath)),
-  resolve: (...paths) => path.normalize(path.join(...paths)),
+  dirname: CompilerFileSystem.dirname,
+  resolve: CompilerFileSystem.resolve,
 
   dependencyResolver: (fromUri, reference, options) =>
-    resolveDependencyPath(fromUri, reference, options.cwd),
+    CompilerFileSystem.resolveDependencyPath(fromUri, reference, options.cwd),
 
-  readFile: async (fileUri) => fs.readFile(toFilePath(fileUri), "utf-8"),
+  readFile: async (fileUri) =>
+    fs.readFile(CompilerFileSystem.toFilePath(fileUri), "utf-8"),
 
   writeFile: async (fileUri, content) => {
     try {
-      await fs.writeFile(toFilePath(fileUri), content);
+      await fs.writeFile(CompilerFileSystem.toFilePath(fileUri), content);
       return true;
     } catch {
       return false;
@@ -61,7 +34,10 @@ export const TestFileSystem: CompilerFileSystem = {
   },
   checkExists: async (fileUri) => {
     try {
-      await fs.access(toFilePath(fileUri), fs.constants.R_OK);
+      await fs.access(
+        CompilerFileSystem.toFilePath(fileUri),
+        fs.constants.R_OK,
+      );
       return true;
     } catch {
       return false;

--- a/packages/nn-type-checker/package.json
+++ b/packages/nn-type-checker/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@nn-lang/nn-type-checker",
   "version": "0.1.13",
+  "type": "module",
   "dependencies": {
     "@nn-lang/nn-language": "workspace:^"
   },

--- a/packages/nn-type-checker/package.json
+++ b/packages/nn-type-checker/package.json
@@ -6,7 +6,7 @@
     "@nn-lang/nn-language": "workspace:^"
   },
   "scripts": {
-    "build": "node ../../scripts/ts-build.cjs .",
+    "build": "node ../../scripts/oxc-build.cjs .",
     "clean": "rm -rf ./out"
   },
   "main": "out/src/index.js",

--- a/packages/nn-type-checker/package.json
+++ b/packages/nn-type-checker/package.json
@@ -2,11 +2,10 @@
   "name": "@nn-lang/nn-type-checker",
   "version": "0.1.13",
   "dependencies": {
-    "@nn-lang/nn-language": "workspace:^",
-    "@oxc-project/runtime": "^0.129.0"
+    "@nn-lang/nn-language": "workspace:^"
   },
   "scripts": {
-    "build": "node ../../scripts/oxc-build.cjs .",
+    "build": "node ../../scripts/ts-build.cjs .",
     "clean": "rm -rf ./out"
   },
   "main": "out/src/index.js",

--- a/scripts/oxc-build.cjs
+++ b/scripts/oxc-build.cjs
@@ -1,12 +1,12 @@
 const fs = require("node:fs");
 const path = require("node:path");
-const ts = require("typescript");
+const { transformSync } = require("oxc-transform");
 
 const projectRoot = process.cwd();
 const packageArg = process.argv[2];
 
 if (!packageArg) {
-  console.error("Usage: node scripts/ts-build.cjs <package-path>");
+  console.error("Usage: node scripts/oxc-build.cjs <package-path>");
   process.exit(1);
 }
 
@@ -19,8 +19,6 @@ if (!fs.existsSync(srcRoot)) {
   console.error(`Missing src directory: ${srcRoot}`);
   process.exit(1);
 }
-
-fs.rmSync(outSrcRoot, { recursive: true, force: true });
 
 const sourceFiles = [];
 
@@ -55,6 +53,24 @@ function getOutputExtension(filePath) {
   }
 
   return ".js";
+}
+
+function getLangFromExtension(filePath) {
+  const ext = path.extname(filePath);
+
+  if (ext === ".ts" || ext === ".cts" || ext === ".mts") {
+    return "ts";
+  }
+
+  if (ext === ".tsx") {
+    return "tsx";
+  }
+
+  if (ext === ".jsx") {
+    return "jsx";
+  }
+
+  return "js";
 }
 
 function toPosixPath(filePath) {
@@ -130,6 +146,15 @@ function rewriteModuleSpecifiers(code, sourceFilePath) {
 collectSourceFiles(srcRoot);
 
 let hasError = false;
+const packageJsonPath = path.join(packageRoot, "package.json");
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+const outputSourceRoot =
+  typeof packageJson.main === "string" &&
+  packageJson.main.startsWith("out/src/")
+    ? outSrcRoot
+    : outRoot;
+
+fs.rmSync(outputSourceRoot, { recursive: true, force: true });
 
 for (const sourceFilePath of sourceFiles) {
   const sourceCode = fs.readFileSync(sourceFilePath, "utf8");
@@ -143,41 +168,42 @@ for (const sourceFilePath of sourceFiles) {
     /\.[^.]+$/,
     outputExtension,
   );
-  const outputPath = path.join(outSrcRoot, outputRelativePath);
-  const transpiled = ts.transpileModule(sourceCode, {
-    compilerOptions: {
-      module: ts.ModuleKind.ES2020,
-      target: ts.ScriptTarget.ES2020,
-      sourceMap: true,
-      esModuleInterop: true,
-      importsNotUsedAsValues: ts.ImportsNotUsedAsValues.Remove,
-    },
-    fileName: relativeFromPackage,
+  const outputPath = path.join(outputSourceRoot, outputRelativePath);
+  const transformed = transformSync(relativeFromPackage, sourceCode, {
+    lang: getLangFromExtension(sourceFilePath),
+    sourceType: "module",
+    sourcemap: true,
+    target: "es2022",
   });
 
-  if (transpiled.diagnostics && transpiled.diagnostics.length > 0) {
+  if (transformed.errors.length > 0) {
     hasError = true;
 
-    for (const diagnostic of transpiled.diagnostics) {
-      const message = ts.flattenDiagnosticMessageText(
-        diagnostic.messageText,
-        "\n",
-      );
-      console.error(`[ts-build] ${relativeFromPackage}: ${message}`);
+    for (const error of transformed.errors) {
+      const message = error.codeframe
+        ? `${error.message}\n${error.codeframe}`
+        : error.message;
+      console.error(`[oxc-build] ${relativeFromPackage}: ${message}`);
     }
 
     continue;
   }
 
   fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  const outputCode = rewriteModuleSpecifiers(transformed.code, sourceFilePath);
+
   fs.writeFileSync(
     outputPath,
-    rewriteModuleSpecifiers(transpiled.outputText, sourceFilePath),
+    `${outputCode}\n//# sourceMappingURL=${path.basename(outputPath)}.map\n`,
     "utf8",
   );
 
-  if (transpiled.sourceMapText) {
-    fs.writeFileSync(`${outputPath}.map`, transpiled.sourceMapText, "utf8");
+  if (transformed.map) {
+    fs.writeFileSync(
+      `${outputPath}.map`,
+      JSON.stringify(transformed.map),
+      "utf8",
+    );
   }
 }
 

--- a/scripts/ts-build.cjs
+++ b/scripts/ts-build.cjs
@@ -57,6 +57,76 @@ function getOutputExtension(filePath) {
   return ".js";
 }
 
+function toPosixPath(filePath) {
+  return filePath.split(path.sep).join("/");
+}
+
+function resolveSourceSpecifier(sourceFilePath, specifier) {
+  if (!specifier.startsWith(".")) {
+    return specifier;
+  }
+
+  const sourceDir = path.dirname(sourceFilePath);
+  const resolvedPath = path.resolve(sourceDir, specifier);
+  const ext = path.extname(resolvedPath);
+
+  if (ext) {
+    return specifier;
+  }
+
+  const candidates = [
+    resolvedPath,
+    `${resolvedPath}.ts`,
+    `${resolvedPath}.tsx`,
+    `${resolvedPath}.mts`,
+    `${resolvedPath}.cts`,
+    `${resolvedPath}.js`,
+    `${resolvedPath}.jsx`,
+    `${resolvedPath}.mjs`,
+    `${resolvedPath}.cjs`,
+    path.join(resolvedPath, "index.ts"),
+    path.join(resolvedPath, "index.tsx"),
+    path.join(resolvedPath, "index.mts"),
+    path.join(resolvedPath, "index.cts"),
+    path.join(resolvedPath, "index.js"),
+    path.join(resolvedPath, "index.jsx"),
+    path.join(resolvedPath, "index.mjs"),
+    path.join(resolvedPath, "index.cjs"),
+  ];
+
+  const targetPath = candidates.find(
+    (candidate) => fs.existsSync(candidate) && fs.statSync(candidate).isFile(),
+  );
+
+  if (!targetPath) {
+    return `${specifier}.js`;
+  }
+
+  const outputExtension = getOutputExtension(targetPath);
+  const outputTargetPath = targetPath.replace(/\.[^.]+$/, outputExtension);
+  let relativePath = toPosixPath(path.relative(sourceDir, outputTargetPath));
+
+  if (!relativePath.startsWith(".")) {
+    relativePath = `./${relativePath}`;
+  }
+
+  return relativePath;
+}
+
+function rewriteModuleSpecifiers(code, sourceFilePath) {
+  return code
+    .replace(
+      /\b(from\s*["'])([^"']+)(["'])/g,
+      (_match, prefix, specifier, suffix) =>
+        `${prefix}${resolveSourceSpecifier(sourceFilePath, specifier)}${suffix}`,
+    )
+    .replace(
+      /\b(import\s*\(\s*["'])([^"']+)(["']\s*\))/g,
+      (_match, prefix, specifier, suffix) =>
+        `${prefix}${resolveSourceSpecifier(sourceFilePath, specifier)}${suffix}`,
+    );
+}
+
 collectSourceFiles(srcRoot);
 
 let hasError = false;
@@ -76,7 +146,7 @@ for (const sourceFilePath of sourceFiles) {
   const outputPath = path.join(outSrcRoot, outputRelativePath);
   const transpiled = ts.transpileModule(sourceCode, {
     compilerOptions: {
-      module: ts.ModuleKind.CommonJS,
+      module: ts.ModuleKind.ES2020,
       target: ts.ScriptTarget.ES2020,
       sourceMap: true,
       esModuleInterop: true,
@@ -100,7 +170,11 @@ for (const sourceFilePath of sourceFiles) {
   }
 
   fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-  fs.writeFileSync(outputPath, transpiled.outputText, "utf8");
+  fs.writeFileSync(
+    outputPath,
+    rewriteModuleSpecifiers(transpiled.outputText, sourceFilePath),
+    "utf8",
+  );
 
   if (transpiled.sourceMapText) {
     fs.writeFileSync(`${outputPath}.map`, transpiled.sourceMapText, "utf8");

--- a/scripts/ts-build.cjs
+++ b/scripts/ts-build.cjs
@@ -1,13 +1,12 @@
 const fs = require("node:fs");
 const path = require("node:path");
-const { transformSync } = require("oxc-transform");
 const ts = require("typescript");
 
 const projectRoot = process.cwd();
 const packageArg = process.argv[2];
 
 if (!packageArg) {
-  console.error("Usage: node scripts/oxc-build.cjs <package-path>");
+  console.error("Usage: node scripts/ts-build.cjs <package-path>");
   process.exit(1);
 }
 
@@ -44,24 +43,6 @@ function collectSourceFiles(currentDir) {
   }
 }
 
-function getLangFromExtension(filePath) {
-  const ext = path.extname(filePath);
-
-  if (ext === ".ts" || ext === ".cts" || ext === ".mts") {
-    return "ts";
-  }
-
-  if (ext === ".tsx") {
-    return "tsx";
-  }
-
-  if (ext === ".jsx") {
-    return "jsx";
-  }
-
-  return "js";
-}
-
 function getOutputExtension(filePath) {
   const ext = path.extname(filePath);
 
@@ -93,34 +74,15 @@ for (const sourceFilePath of sourceFiles) {
     outputExtension,
   );
   const outputPath = path.join(outSrcRoot, outputRelativePath);
-  const result = transformSync(relativeFromPackage, sourceCode, {
-    lang: getLangFromExtension(sourceFilePath),
-    sourceType: "commonjs",
-    sourcemap: false,
-    target: "es2015",
-  });
-
-  if (result.errors.length > 0) {
-    hasError = true;
-
-    for (const error of result.errors) {
-      const message = error.codeframe
-        ? `${error.message}\n${error.codeframe}`
-        : error.message;
-      console.error(`[oxc-build] ${relativeFromPackage}: ${message}`);
-    }
-
-    continue;
-  }
-
-  const transpiled = ts.transpileModule(result.code, {
+  const transpiled = ts.transpileModule(sourceCode, {
     compilerOptions: {
       module: ts.ModuleKind.CommonJS,
-      target: ts.ScriptTarget.ESNext,
+      target: ts.ScriptTarget.ES2020,
       sourceMap: true,
       esModuleInterop: true,
+      importsNotUsedAsValues: ts.ImportsNotUsedAsValues.Remove,
     },
-    fileName: path.basename(outputPath),
+    fileName: relativeFromPackage,
   });
 
   if (transpiled.diagnostics && transpiled.diagnostics.length > 0) {
@@ -131,7 +93,7 @@ for (const sourceFilePath of sourceFiles) {
         diagnostic.messageText,
         "\n",
       );
-      console.error(`[oxc-build] ${relativeFromPackage}: ${message}`);
+      console.error(`[ts-build] ${relativeFromPackage}: ${message}`);
     }
 
     continue;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1109,34 +1109,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emnapi/core@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@emnapi/core@npm:1.10.0"
-  dependencies:
-    "@emnapi/wasi-threads": "npm:1.2.1"
-    tslib: "npm:^2.4.0"
-  checksum: 10c0/f51d08227857b60632de7714d708124f0e100a1462dde6df8221760939aa3204a73193830371830fac0716f3ccd2129f2cac1b17cd7d7958bc4da9018a296edb
-  languageName: node
-  linkType: hard
-
-"@emnapi/runtime@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@emnapi/runtime@npm:1.10.0"
-  dependencies:
-    tslib: "npm:^2.4.0"
-  checksum: 10c0/953f14991d1aefb92ee6f8eb27dea725e484791a53a0cb5f47d9e0087b9a2c929ff2e92adf95af15d6ad456db6300c6b761ebf72b50a875b874a83520b3ba093
-  languageName: node
-  linkType: hard
-
-"@emnapi/wasi-threads@npm:1.2.1":
-  version: 1.2.1
-  resolution: "@emnapi/wasi-threads@npm:1.2.1"
-  dependencies:
-    tslib: "npm:^2.4.0"
-  checksum: 10c0/32fcfa81ab396533b2ec1f4082b1ff779a05d9c836bbbd3f4398405b0e6814c0d9503b7993130e37bc6941dbc1ded49f55e9700ae9ca4e803bab2b5bc5deb331
-  languageName: node
-  linkType: hard
-
 "@inquirer/checkbox@npm:^4.1.6":
   version: 4.1.6
   resolution: "@inquirer/checkbox@npm:4.1.6"
@@ -1765,25 +1737,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@napi-rs/wasm-runtime@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "@napi-rs/wasm-runtime@npm:1.1.4"
-  dependencies:
-    "@tybys/wasm-util": "npm:^0.10.1"
-  peerDependencies:
-    "@emnapi/core": ^1.7.1
-    "@emnapi/runtime": ^1.7.1
-  checksum: 10c0/2e88e1955258949ccf2d18c79975821ad38071b465ef126a5e14110977b97868867b016c1ad046e963cccc42c0bd9db6c8ff5fd1ebb61b87bb3487f339041658
-  languageName: node
-  linkType: hard
-
 "@nn-lang/nn-analyzer@workspace:^, @nn-lang/nn-analyzer@workspace:packages/nn-analyzer":
   version: 0.0.0-use.local
   resolution: "@nn-lang/nn-analyzer@workspace:packages/nn-analyzer"
   dependencies:
     "@nn-lang/nn-language": "workspace:^"
     "@nn-lang/nn-type-checker": "workspace:^"
-    "@oxc-project/runtime": "npm:^0.129.0"
   languageName: unknown
   linkType: soft
 
@@ -1819,7 +1778,6 @@ __metadata:
   dependencies:
     "@nn-lang/nn-language": "workspace:^"
     "@nn-lang/nn-type-checker": "workspace:^"
-    "@oxc-project/runtime": "npm:^0.129.0"
     onnx-proto: "npm:^8.0.1"
   languageName: unknown
   linkType: soft
@@ -1828,7 +1786,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nn-lang/nn-language@workspace:packages/nn-language"
   dependencies:
-    "@oxc-project/runtime": "npm:^0.129.0"
     web-tree-sitter: "npm:^0.25.3"
   languageName: unknown
   linkType: soft
@@ -1868,7 +1825,6 @@ __metadata:
   resolution: "@nn-lang/nn-type-checker@workspace:packages/nn-type-checker"
   dependencies:
     "@nn-lang/nn-language": "workspace:^"
-    "@oxc-project/runtime": "npm:^0.129.0"
   languageName: unknown
   linkType: soft
 
@@ -1877,7 +1833,6 @@ __metadata:
   resolution: "@nn-lang/nn@workspace:."
   dependencies:
     "@dotenvx/dotenvx": "npm:^1.44.1"
-    oxc-transform: "npm:^0.129.0"
     oxfmt: "npm:^0.48.0"
     oxlint: "npm:^1.63.0"
     ts-features: "npm:^2.0.0"
@@ -2228,157 +2183,6 @@ __metadata:
   peerDependencies:
     "@oclif/core": ">= 3.0.0"
   checksum: 10c0/59f0246f8980c45d8c0cd9a62b2d57ef4b1a21e0e6e3468451ef42e2811414878f5adcbd793b7d7d623c082bca8b446201263e62a0c6ba4c733633474a36139f
-  languageName: node
-  linkType: hard
-
-"@oxc-project/runtime@npm:^0.129.0":
-  version: 0.129.0
-  resolution: "@oxc-project/runtime@npm:0.129.0"
-  checksum: 10c0/e262104ff08092d0b7351095b414c543035aed54ac38a69f35687c5c401a923063442c54892af7ec5fc50aff5aebd2988f1731a84d3620a79a26a04f4e1f4a54
-  languageName: node
-  linkType: hard
-
-"@oxc-transform/binding-android-arm-eabi@npm:0.129.0":
-  version: 0.129.0
-  resolution: "@oxc-transform/binding-android-arm-eabi@npm:0.129.0"
-  conditions: os=android & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@oxc-transform/binding-android-arm64@npm:0.129.0":
-  version: 0.129.0
-  resolution: "@oxc-transform/binding-android-arm64@npm:0.129.0"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@oxc-transform/binding-darwin-arm64@npm:0.129.0":
-  version: 0.129.0
-  resolution: "@oxc-transform/binding-darwin-arm64@npm:0.129.0"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@oxc-transform/binding-darwin-x64@npm:0.129.0":
-  version: 0.129.0
-  resolution: "@oxc-transform/binding-darwin-x64@npm:0.129.0"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@oxc-transform/binding-freebsd-x64@npm:0.129.0":
-  version: 0.129.0
-  resolution: "@oxc-transform/binding-freebsd-x64@npm:0.129.0"
-  conditions: os=freebsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@oxc-transform/binding-linux-arm-gnueabihf@npm:0.129.0":
-  version: 0.129.0
-  resolution: "@oxc-transform/binding-linux-arm-gnueabihf@npm:0.129.0"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@oxc-transform/binding-linux-arm-musleabihf@npm:0.129.0":
-  version: 0.129.0
-  resolution: "@oxc-transform/binding-linux-arm-musleabihf@npm:0.129.0"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@oxc-transform/binding-linux-arm64-gnu@npm:0.129.0":
-  version: 0.129.0
-  resolution: "@oxc-transform/binding-linux-arm64-gnu@npm:0.129.0"
-  conditions: os=linux & cpu=arm64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@oxc-transform/binding-linux-arm64-musl@npm:0.129.0":
-  version: 0.129.0
-  resolution: "@oxc-transform/binding-linux-arm64-musl@npm:0.129.0"
-  conditions: os=linux & cpu=arm64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@oxc-transform/binding-linux-ppc64-gnu@npm:0.129.0":
-  version: 0.129.0
-  resolution: "@oxc-transform/binding-linux-ppc64-gnu@npm:0.129.0"
-  conditions: os=linux & cpu=ppc64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@oxc-transform/binding-linux-riscv64-gnu@npm:0.129.0":
-  version: 0.129.0
-  resolution: "@oxc-transform/binding-linux-riscv64-gnu@npm:0.129.0"
-  conditions: os=linux & cpu=riscv64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@oxc-transform/binding-linux-riscv64-musl@npm:0.129.0":
-  version: 0.129.0
-  resolution: "@oxc-transform/binding-linux-riscv64-musl@npm:0.129.0"
-  conditions: os=linux & cpu=riscv64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@oxc-transform/binding-linux-s390x-gnu@npm:0.129.0":
-  version: 0.129.0
-  resolution: "@oxc-transform/binding-linux-s390x-gnu@npm:0.129.0"
-  conditions: os=linux & cpu=s390x & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@oxc-transform/binding-linux-x64-gnu@npm:0.129.0":
-  version: 0.129.0
-  resolution: "@oxc-transform/binding-linux-x64-gnu@npm:0.129.0"
-  conditions: os=linux & cpu=x64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@oxc-transform/binding-linux-x64-musl@npm:0.129.0":
-  version: 0.129.0
-  resolution: "@oxc-transform/binding-linux-x64-musl@npm:0.129.0"
-  conditions: os=linux & cpu=x64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@oxc-transform/binding-openharmony-arm64@npm:0.129.0":
-  version: 0.129.0
-  resolution: "@oxc-transform/binding-openharmony-arm64@npm:0.129.0"
-  conditions: os=openharmony & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@oxc-transform/binding-wasm32-wasi@npm:0.129.0":
-  version: 0.129.0
-  resolution: "@oxc-transform/binding-wasm32-wasi@npm:0.129.0"
-  dependencies:
-    "@emnapi/core": "npm:1.10.0"
-    "@emnapi/runtime": "npm:1.10.0"
-    "@napi-rs/wasm-runtime": "npm:^1.1.4"
-  conditions: cpu=wasm32
-  languageName: node
-  linkType: hard
-
-"@oxc-transform/binding-win32-arm64-msvc@npm:0.129.0":
-  version: 0.129.0
-  resolution: "@oxc-transform/binding-win32-arm64-msvc@npm:0.129.0"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@oxc-transform/binding-win32-ia32-msvc@npm:0.129.0":
-  version: 0.129.0
-  resolution: "@oxc-transform/binding-win32-ia32-msvc@npm:0.129.0"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"@oxc-transform/binding-win32-x64-msvc@npm:0.129.0":
-  version: 0.129.0
-  resolution: "@oxc-transform/binding-win32-x64-msvc@npm:0.129.0"
-  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -3493,15 +3297,6 @@ __metadata:
     "@tufjs/canonical-json": "npm:2.0.0"
     minimatch: "npm:^9.0.5"
   checksum: 10c0/0b2022589139102edf28f7fdcd094407fc98ac25bf530ebcf538dd63152baea9b6144b713c8dfc4f6b7580adeff706ab6ecc5f9716c4b816e58a04419abb1926
-  languageName: node
-  linkType: hard
-
-"@tybys/wasm-util@npm:^0.10.1":
-  version: 0.10.2
-  resolution: "@tybys/wasm-util@npm:0.10.2"
-  dependencies:
-    tslib: "npm:^2.4.0"
-  checksum: 10c0/26165bcd1fd7269f42d7fbe3de318f854a8968de8397e89fc9a423bb3e2da35a52150f382e6323b3367595beb16d9800a6f35971a5599daf76da1742ec3afc25
   languageName: node
   linkType: hard
 
@@ -7136,75 +6931,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"oxc-transform@npm:^0.129.0":
-  version: 0.129.0
-  resolution: "oxc-transform@npm:0.129.0"
-  dependencies:
-    "@oxc-transform/binding-android-arm-eabi": "npm:0.129.0"
-    "@oxc-transform/binding-android-arm64": "npm:0.129.0"
-    "@oxc-transform/binding-darwin-arm64": "npm:0.129.0"
-    "@oxc-transform/binding-darwin-x64": "npm:0.129.0"
-    "@oxc-transform/binding-freebsd-x64": "npm:0.129.0"
-    "@oxc-transform/binding-linux-arm-gnueabihf": "npm:0.129.0"
-    "@oxc-transform/binding-linux-arm-musleabihf": "npm:0.129.0"
-    "@oxc-transform/binding-linux-arm64-gnu": "npm:0.129.0"
-    "@oxc-transform/binding-linux-arm64-musl": "npm:0.129.0"
-    "@oxc-transform/binding-linux-ppc64-gnu": "npm:0.129.0"
-    "@oxc-transform/binding-linux-riscv64-gnu": "npm:0.129.0"
-    "@oxc-transform/binding-linux-riscv64-musl": "npm:0.129.0"
-    "@oxc-transform/binding-linux-s390x-gnu": "npm:0.129.0"
-    "@oxc-transform/binding-linux-x64-gnu": "npm:0.129.0"
-    "@oxc-transform/binding-linux-x64-musl": "npm:0.129.0"
-    "@oxc-transform/binding-openharmony-arm64": "npm:0.129.0"
-    "@oxc-transform/binding-wasm32-wasi": "npm:0.129.0"
-    "@oxc-transform/binding-win32-arm64-msvc": "npm:0.129.0"
-    "@oxc-transform/binding-win32-ia32-msvc": "npm:0.129.0"
-    "@oxc-transform/binding-win32-x64-msvc": "npm:0.129.0"
-  dependenciesMeta:
-    "@oxc-transform/binding-android-arm-eabi":
-      optional: true
-    "@oxc-transform/binding-android-arm64":
-      optional: true
-    "@oxc-transform/binding-darwin-arm64":
-      optional: true
-    "@oxc-transform/binding-darwin-x64":
-      optional: true
-    "@oxc-transform/binding-freebsd-x64":
-      optional: true
-    "@oxc-transform/binding-linux-arm-gnueabihf":
-      optional: true
-    "@oxc-transform/binding-linux-arm-musleabihf":
-      optional: true
-    "@oxc-transform/binding-linux-arm64-gnu":
-      optional: true
-    "@oxc-transform/binding-linux-arm64-musl":
-      optional: true
-    "@oxc-transform/binding-linux-ppc64-gnu":
-      optional: true
-    "@oxc-transform/binding-linux-riscv64-gnu":
-      optional: true
-    "@oxc-transform/binding-linux-riscv64-musl":
-      optional: true
-    "@oxc-transform/binding-linux-s390x-gnu":
-      optional: true
-    "@oxc-transform/binding-linux-x64-gnu":
-      optional: true
-    "@oxc-transform/binding-linux-x64-musl":
-      optional: true
-    "@oxc-transform/binding-openharmony-arm64":
-      optional: true
-    "@oxc-transform/binding-wasm32-wasi":
-      optional: true
-    "@oxc-transform/binding-win32-arm64-msvc":
-      optional: true
-    "@oxc-transform/binding-win32-ia32-msvc":
-      optional: true
-    "@oxc-transform/binding-win32-x64-msvc":
-      optional: true
-  checksum: 10c0/a9ff12865464cc1e5cf2278ccb19848b78cb387a090b347a8be8ddb039c810ecf4fe8c49957313592df834943b3fc4b69c5c255e93617f91c93f3f48728a2c49
-  languageName: node
-  linkType: hard
-
 "oxfmt@npm:^0.48.0":
   version: 0.48.0
   resolution: "oxfmt@npm:0.48.0"
@@ -8665,7 +8391,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.3, tslib@npm:^2.4.0, tslib@npm:^2.6.2":
+"tslib@npm:^2.0.3, tslib@npm:^2.6.2":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62

--- a/yarn.lock
+++ b/yarn.lock
@@ -1109,6 +1109,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/core@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@emnapi/core@npm:1.10.0"
+  dependencies:
+    "@emnapi/wasi-threads": "npm:1.2.1"
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/f51d08227857b60632de7714d708124f0e100a1462dde6df8221760939aa3204a73193830371830fac0716f3ccd2129f2cac1b17cd7d7958bc4da9018a296edb
+  languageName: node
+  linkType: hard
+
+"@emnapi/runtime@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@emnapi/runtime@npm:1.10.0"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/953f14991d1aefb92ee6f8eb27dea725e484791a53a0cb5f47d9e0087b9a2c929ff2e92adf95af15d6ad456db6300c6b761ebf72b50a875b874a83520b3ba093
+  languageName: node
+  linkType: hard
+
+"@emnapi/wasi-threads@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@emnapi/wasi-threads@npm:1.2.1"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/32fcfa81ab396533b2ec1f4082b1ff779a05d9c836bbbd3f4398405b0e6814c0d9503b7993130e37bc6941dbc1ded49f55e9700ae9ca4e803bab2b5bc5deb331
+  languageName: node
+  linkType: hard
+
 "@inquirer/checkbox@npm:^4.1.6":
   version: 4.1.6
   resolution: "@inquirer/checkbox@npm:4.1.6"
@@ -1737,6 +1765,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@napi-rs/wasm-runtime@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "@napi-rs/wasm-runtime@npm:1.1.4"
+  dependencies:
+    "@tybys/wasm-util": "npm:^0.10.1"
+  peerDependencies:
+    "@emnapi/core": ^1.7.1
+    "@emnapi/runtime": ^1.7.1
+  checksum: 10c0/2e88e1955258949ccf2d18c79975821ad38071b465ef126a5e14110977b97868867b016c1ad046e963cccc42c0bd9db6c8ff5fd1ebb61b87bb3487f339041658
+  languageName: node
+  linkType: hard
+
 "@nn-lang/nn-analyzer@workspace:^, @nn-lang/nn-analyzer@workspace:packages/nn-analyzer":
   version: 0.0.0-use.local
   resolution: "@nn-lang/nn-analyzer@workspace:packages/nn-analyzer"
@@ -1833,6 +1873,7 @@ __metadata:
   resolution: "@nn-lang/nn@workspace:."
   dependencies:
     "@dotenvx/dotenvx": "npm:^1.44.1"
+    oxc-transform: "npm:^0.133.0"
     oxfmt: "npm:^0.48.0"
     oxlint: "npm:^1.63.0"
     ts-features: "npm:^2.0.0"
@@ -2183,6 +2224,150 @@ __metadata:
   peerDependencies:
     "@oclif/core": ">= 3.0.0"
   checksum: 10c0/59f0246f8980c45d8c0cd9a62b2d57ef4b1a21e0e6e3468451ef42e2811414878f5adcbd793b7d7d623c082bca8b446201263e62a0c6ba4c733633474a36139f
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-android-arm-eabi@npm:0.133.0":
+  version: 0.133.0
+  resolution: "@oxc-transform/binding-android-arm-eabi@npm:0.133.0"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-android-arm64@npm:0.133.0":
+  version: 0.133.0
+  resolution: "@oxc-transform/binding-android-arm64@npm:0.133.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-darwin-arm64@npm:0.133.0":
+  version: 0.133.0
+  resolution: "@oxc-transform/binding-darwin-arm64@npm:0.133.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-darwin-x64@npm:0.133.0":
+  version: 0.133.0
+  resolution: "@oxc-transform/binding-darwin-x64@npm:0.133.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-freebsd-x64@npm:0.133.0":
+  version: 0.133.0
+  resolution: "@oxc-transform/binding-freebsd-x64@npm:0.133.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-linux-arm-gnueabihf@npm:0.133.0":
+  version: 0.133.0
+  resolution: "@oxc-transform/binding-linux-arm-gnueabihf@npm:0.133.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-linux-arm-musleabihf@npm:0.133.0":
+  version: 0.133.0
+  resolution: "@oxc-transform/binding-linux-arm-musleabihf@npm:0.133.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-linux-arm64-gnu@npm:0.133.0":
+  version: 0.133.0
+  resolution: "@oxc-transform/binding-linux-arm64-gnu@npm:0.133.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-linux-arm64-musl@npm:0.133.0":
+  version: 0.133.0
+  resolution: "@oxc-transform/binding-linux-arm64-musl@npm:0.133.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-linux-ppc64-gnu@npm:0.133.0":
+  version: 0.133.0
+  resolution: "@oxc-transform/binding-linux-ppc64-gnu@npm:0.133.0"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-linux-riscv64-gnu@npm:0.133.0":
+  version: 0.133.0
+  resolution: "@oxc-transform/binding-linux-riscv64-gnu@npm:0.133.0"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-linux-riscv64-musl@npm:0.133.0":
+  version: 0.133.0
+  resolution: "@oxc-transform/binding-linux-riscv64-musl@npm:0.133.0"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-linux-s390x-gnu@npm:0.133.0":
+  version: 0.133.0
+  resolution: "@oxc-transform/binding-linux-s390x-gnu@npm:0.133.0"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-linux-x64-gnu@npm:0.133.0":
+  version: 0.133.0
+  resolution: "@oxc-transform/binding-linux-x64-gnu@npm:0.133.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-linux-x64-musl@npm:0.133.0":
+  version: 0.133.0
+  resolution: "@oxc-transform/binding-linux-x64-musl@npm:0.133.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-openharmony-arm64@npm:0.133.0":
+  version: 0.133.0
+  resolution: "@oxc-transform/binding-openharmony-arm64@npm:0.133.0"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-wasm32-wasi@npm:0.133.0":
+  version: 0.133.0
+  resolution: "@oxc-transform/binding-wasm32-wasi@npm:0.133.0"
+  dependencies:
+    "@emnapi/core": "npm:1.10.0"
+    "@emnapi/runtime": "npm:1.10.0"
+    "@napi-rs/wasm-runtime": "npm:^1.1.4"
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-win32-arm64-msvc@npm:0.133.0":
+  version: 0.133.0
+  resolution: "@oxc-transform/binding-win32-arm64-msvc@npm:0.133.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-win32-ia32-msvc@npm:0.133.0":
+  version: 0.133.0
+  resolution: "@oxc-transform/binding-win32-ia32-msvc@npm:0.133.0"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-win32-x64-msvc@npm:0.133.0":
+  version: 0.133.0
+  resolution: "@oxc-transform/binding-win32-x64-msvc@npm:0.133.0"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -3297,6 +3482,15 @@ __metadata:
     "@tufjs/canonical-json": "npm:2.0.0"
     minimatch: "npm:^9.0.5"
   checksum: 10c0/0b2022589139102edf28f7fdcd094407fc98ac25bf530ebcf538dd63152baea9b6144b713c8dfc4f6b7580adeff706ab6ecc5f9716c4b816e58a04419abb1926
+  languageName: node
+  linkType: hard
+
+"@tybys/wasm-util@npm:^0.10.1":
+  version: 0.10.2
+  resolution: "@tybys/wasm-util@npm:0.10.2"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/26165bcd1fd7269f42d7fbe3de318f854a8968de8397e89fc9a423bb3e2da35a52150f382e6323b3367595beb16d9800a6f35971a5599daf76da1742ec3afc25
   languageName: node
   linkType: hard
 
@@ -6931,6 +7125,75 @@ __metadata:
   languageName: node
   linkType: hard
 
+"oxc-transform@npm:^0.133.0":
+  version: 0.133.0
+  resolution: "oxc-transform@npm:0.133.0"
+  dependencies:
+    "@oxc-transform/binding-android-arm-eabi": "npm:0.133.0"
+    "@oxc-transform/binding-android-arm64": "npm:0.133.0"
+    "@oxc-transform/binding-darwin-arm64": "npm:0.133.0"
+    "@oxc-transform/binding-darwin-x64": "npm:0.133.0"
+    "@oxc-transform/binding-freebsd-x64": "npm:0.133.0"
+    "@oxc-transform/binding-linux-arm-gnueabihf": "npm:0.133.0"
+    "@oxc-transform/binding-linux-arm-musleabihf": "npm:0.133.0"
+    "@oxc-transform/binding-linux-arm64-gnu": "npm:0.133.0"
+    "@oxc-transform/binding-linux-arm64-musl": "npm:0.133.0"
+    "@oxc-transform/binding-linux-ppc64-gnu": "npm:0.133.0"
+    "@oxc-transform/binding-linux-riscv64-gnu": "npm:0.133.0"
+    "@oxc-transform/binding-linux-riscv64-musl": "npm:0.133.0"
+    "@oxc-transform/binding-linux-s390x-gnu": "npm:0.133.0"
+    "@oxc-transform/binding-linux-x64-gnu": "npm:0.133.0"
+    "@oxc-transform/binding-linux-x64-musl": "npm:0.133.0"
+    "@oxc-transform/binding-openharmony-arm64": "npm:0.133.0"
+    "@oxc-transform/binding-wasm32-wasi": "npm:0.133.0"
+    "@oxc-transform/binding-win32-arm64-msvc": "npm:0.133.0"
+    "@oxc-transform/binding-win32-ia32-msvc": "npm:0.133.0"
+    "@oxc-transform/binding-win32-x64-msvc": "npm:0.133.0"
+  dependenciesMeta:
+    "@oxc-transform/binding-android-arm-eabi":
+      optional: true
+    "@oxc-transform/binding-android-arm64":
+      optional: true
+    "@oxc-transform/binding-darwin-arm64":
+      optional: true
+    "@oxc-transform/binding-darwin-x64":
+      optional: true
+    "@oxc-transform/binding-freebsd-x64":
+      optional: true
+    "@oxc-transform/binding-linux-arm-gnueabihf":
+      optional: true
+    "@oxc-transform/binding-linux-arm-musleabihf":
+      optional: true
+    "@oxc-transform/binding-linux-arm64-gnu":
+      optional: true
+    "@oxc-transform/binding-linux-arm64-musl":
+      optional: true
+    "@oxc-transform/binding-linux-ppc64-gnu":
+      optional: true
+    "@oxc-transform/binding-linux-riscv64-gnu":
+      optional: true
+    "@oxc-transform/binding-linux-riscv64-musl":
+      optional: true
+    "@oxc-transform/binding-linux-s390x-gnu":
+      optional: true
+    "@oxc-transform/binding-linux-x64-gnu":
+      optional: true
+    "@oxc-transform/binding-linux-x64-musl":
+      optional: true
+    "@oxc-transform/binding-openharmony-arm64":
+      optional: true
+    "@oxc-transform/binding-wasm32-wasi":
+      optional: true
+    "@oxc-transform/binding-win32-arm64-msvc":
+      optional: true
+    "@oxc-transform/binding-win32-ia32-msvc":
+      optional: true
+    "@oxc-transform/binding-win32-x64-msvc":
+      optional: true
+  checksum: 10c0/4c4ad1b362844594d2e617071df61e20c890765dac3e544b3ae67974c3742f5b92b882e3ede26bd904d29b7f1e6bb87239e074cc9f562937938c0e22d0f8e9e7
+  languageName: node
+  linkType: hard
+
 "oxfmt@npm:^0.48.0":
   version: 0.48.0
   resolution: "oxfmt@npm:0.48.0"
@@ -8391,7 +8654,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.3, tslib@npm:^2.6.2":
+"tslib@npm:^2.0.3, tslib@npm:^2.4.0, tslib@npm:^2.6.2":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62


### PR DESCRIPTION
## 요약
- 패키지 빌드 파이프라인에서 OXC transform 단계를 제거하고 TypeScript 단일 transpile 스크립트로 단순화했습니다.
- CLI와 테스트의 파일 시스템 URI/path 처리 중복을 `CompilerFileSystem` 공유 헬퍼로 통합했습니다.
- `travel()`의 `pos`/`path` 기반 휴리스틱을 명시적인 Node/metadata 구조 가드로 대체하고 회귀 테스트를 추가했습니다.

## 검증
- `yarn build`
- `yarn test`
- `yarn lint`
- `yarn format:check`
- `yarn nn-cli check packages/nn-test/tests/cases/Linear.nn`